### PR TITLE
Allow filter queries (fq) in LireRequestHandler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-#Mon Feb 13 12:08:49 CET 2017
-buildNumber=153
+#Tue Aug 29 16:24:53 CEST 2017
 versionString=6.4.0_b01
-buildDate=2017-02-13-1208
+buildNumber=154
+buildDate=2017-08-29-1624


### PR DESCRIPTION
Now it is possible to use filter queries with the LireRequestHandler. For example, assuming you have a "category" field in the lire schema, you can do: http://your_solr_server:8983/solr/lire/lireq?url=http://some_image_url.com&fq=category:sports. This will return similar images as always, but only of the "sports" category.
The rest of parameters (field, rows, ms, etc.) works as always.
The handleRandomSearch method is also changed to work with filter queries.

Previously, filterQuery parameter was ALWAYS null.