### PR TITLE
Workarounds to work with Solr 7.x. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ classes/
 /.project
 /.settings
 /dist/
+/gradle.properties

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ apply plugin: 'project-report'
 sourceCompatibility = 1.8
 version = project.property('versionString') + '_build' + project.property('buildNumber')
 
+def solrVersion = '7.2.1'
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -17,17 +19,17 @@ repositories {
 
 dependencies {
     // ---< Lucene >---
-    compile group: 'org.apache.lucene', name: 'lucene-core', version: '6.4.0'
-    compile group: 'org.apache.lucene', name: 'lucene-analyzers-common', version: '6.4.0'
-    compile group: 'org.apache.lucene', name: 'lucene-queryparser', version: '6.4.0'
-    compile group: 'org.apache.lucene', name: 'lucene-queries', version: '6.4.0'
+    compile group: 'org.apache.lucene', name: 'lucene-core', version: solrVersion
+    compile group: 'org.apache.lucene', name: 'lucene-analyzers-common', version: solrVersion
+    compile group: 'org.apache.lucene', name: 'lucene-queryparser', version: solrVersion
+    compile group: 'org.apache.lucene', name: 'lucene-queries', version: solrVersion
 
     // ---< Solr >---
     // https://mvnrepository.com/artifact/org.apache.solr/solr-core
-    compile group: 'org.apache.solr', name: 'solr-core', version: '6.4.0'
+    compile group: 'org.apache.solr', name: 'solr-core', version: solrVersion
     // https://mvnrepository.com/artifact/org.apache.solr/solr-dataimporthandler
-    compile group: 'org.apache.solr', name: 'solr-dataimporthandler', version: '6.4.0'
-    compile group: 'org.apache.solr', name: 'solr-solrj', version: '6.4.0'
+    compile group: 'org.apache.solr', name: 'solr-dataimporthandler', version: solrVersion
+    compile group: 'org.apache.solr', name: 'solr-solrj', version: solrVersion
     // https://mvnrepository.com/artifact/org.apache.solr/solr-solrj
 
     // ---< Commons >---

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-#Tue Aug 29 16:24:53 CEST 2017
+#Fri Feb 02 17:11:26 EST 2018
 versionString=6.4.0_b01
-buildNumber=154
-buildDate=2017-08-29-1624
+buildNumber=162
+buildDate=2018-02-02-1711

--- a/src/main/java/net/semanticmetadata/lire/solr/BinaryDocValuesField.java
+++ b/src/main/java/net/semanticmetadata/lire/solr/BinaryDocValuesField.java
@@ -83,7 +83,10 @@ public class BinaryDocValuesField extends FieldType {
     @Override
     public ByteBuffer toObject(IndexableField f) {
         BytesRef bytes = f.binaryValue();
-        return  ByteBuffer.wrap(bytes.bytes, bytes.offset, bytes.length);
+        if (bytes != null) {
+            return  ByteBuffer.wrap(bytes.bytes, bytes.offset, bytes.length);
+        }
+        return ByteBuffer.allocate(0);
     }
 
     @Override
@@ -93,7 +96,7 @@ public class BinaryDocValuesField extends FieldType {
     }
 
     @Override
-    public IndexableField createField(SchemaField field, Object val, float boost) {
+    public IndexableField createField(SchemaField field, Object val /*, float boost*/) {
         if (val == null) return null;
         if (!field.stored()) {
             return null;
@@ -118,7 +121,7 @@ public class BinaryDocValuesField extends FieldType {
 
         Field f = new org.apache.lucene.document.BinaryDocValuesField(field.getName(), new BytesRef(buf, offset, len));
 //        Field f = new org.apache.lucene.document.StoredField(field.getName(), buf, offset, len);
-        f.setBoost(boost);
+        //f.setBoost(boost);
         return f;
     }
 }

--- a/src/main/java/net/semanticmetadata/lire/solr/indexing/FileNameDataProcessor.java
+++ b/src/main/java/net/semanticmetadata/lire/solr/indexing/FileNameDataProcessor.java
@@ -1,0 +1,29 @@
+package net.semanticmetadata.lire.solr.indexing;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ *  This data processor removes the path from the file to keep only
+ *  the last segment (the actual file name), and store it as the title. The
+ *  same file name is used for the identifier, minus the extension (if any).
+ *  @author Pascal Essiembre
+ */
+public class FileNameDataProcessor implements ImageDataProcessor {
+
+    @Override
+    public CharSequence getTitle(String filename) {
+        return StringUtils.substringAfterLast(
+                filename.replace('\\', '/'), "/");
+    }
+
+    @Override
+    public CharSequence getIdentifier(String filename) {
+        return StringUtils.substringBefore(StringUtils.substringAfterLast(
+                filename.replace('\\', '/'), "/"), ".");
+    }
+
+    @Override
+    public CharSequence getAdditionalFields(String filename) {
+        return "";
+    }
+}

--- a/src/main/java/net/semanticmetadata/lire/solr/tools/RandomAccessBinaryDocValues.java
+++ b/src/main/java/net/semanticmetadata/lire/solr/tools/RandomAccessBinaryDocValues.java
@@ -1,0 +1,88 @@
+package net.semanticmetadata.lire.solr.tools;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.util.BytesRef;
+
+
+/**
+ * Wraps a {@link BinaryDocValues} creation strategy so it can be reset
+ * if needed.  This is a hack to port liresolr to Lucene 7+ (which enforces
+ * ordered doc values) until a more formal solution is in place.
+ * @author Pascal Essiembre
+ */
+public class RandomAccessBinaryDocValues extends BinaryDocValues {
+
+    private final Supplier<BinaryDocValues> supplier;
+    private BinaryDocValues docValues;
+
+    public RandomAccessBinaryDocValues(Supplier<BinaryDocValues> supplier) {
+        super();
+        this.supplier = supplier;
+        this.docValues = supplier.get();
+    }
+
+    @Override
+    public BytesRef binaryValue() throws IOException {
+        if (docValues == null) {
+            return new BytesRef(BytesRef.EMPTY_BYTES);
+        }
+        return docValues.binaryValue();
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        resetIfNeeded(target);
+        if (docValues == null) {
+            return false;
+        }
+        return docValues.advanceExact(target);
+    }
+
+    @Override
+    public int docID() {
+        if (docValues == null) {
+            return NO_MORE_DOCS;
+        }
+        return docValues.docID();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        if (docValues == null) {
+            return NO_MORE_DOCS;
+        }
+        return docValues.nextDoc();
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        resetIfNeeded(target);
+        if (docValues == null) {
+            return NO_MORE_DOCS;
+        }
+        return docValues.advance(target);
+    }
+
+    @Override
+    public long cost() {
+        if (docValues == null) {
+            return 0;
+        }
+        return docValues.cost();
+    }
+
+    private void resetIfNeeded(int target) {
+        if (docValues == null) {
+            docValues = supplier.get();
+        } else {
+            int id = docValues.docID();
+            if (id != -1 && id != NO_MORE_DOCS
+                    && target < docValues.docID()) {
+                docValues = supplier.get();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello, if you are interested, I modified your code to work with Solr 7.x.  The proposed solution is more a hack to work around the important changes in Lucene DocValues API.  A more formal/efficient solution should probably be put in place at some point, but this is a start.

Since the code targetting Solr 7.x it is not backward compatible with Solr 6.x, maybe a new branch should be created?