### PR TITLE
No extra thread when "-n 1" requests one thread.

### DIFF
--- a/src/main/java/net/semanticmetadata/lire/solr/indexing/ParallelSolrIndexer.java
+++ b/src/main/java/net/semanticmetadata/lire/solr/indexing/ParallelSolrIndexer.java
@@ -335,8 +335,10 @@ public class ParallelSolrIndexer implements Runnable {
                 c.start();
                 threads.add(c);
             }
-            Thread m = new Thread(new Monitoring(), "Monitoring");
-            m.start();
+            if (ParallelSolrIndexer.numberOfThreads > 1) {
+                Thread m = new Thread(new Monitoring(), "Monitoring");
+                m.start();
+            }
             for (Iterator<Thread> iterator = threads.iterator(); iterator.hasNext(); ) {
                 iterator.next().join();
             }


### PR DESCRIPTION
When invoked with "-n 1" an extra monitoring thread should not be created.  The monitoring thread adds ten seconds to the processing.