### PR TITLE
Use same solr version in gradle and docker

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -8,7 +8,7 @@
 # -- Running the docker image
 # $ docker run -p 8983:8983 dermotte/liresolr:latest
 
-FROM solr:6.4.0
+FROM solr:7.2.1
 
 MAINTAINER  Mathias Lux "mathias@juggle.at"
 


### PR DESCRIPTION
It took me a while to figure out why I was getting exceptions at runtime. Hope this helps other.